### PR TITLE
refactoring on the intellij version and switch back to 12.0.4

### DIFF
--- a/install-intellij-libs.sh
+++ b/install-intellij-libs.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 INTELLIJ_HOME=$1
+INTELLIJ_VERSION=12.0.4
 
 if [ -z "$INTELLIJ_HOME" ]
 then
@@ -17,9 +18,9 @@ fi
 echo 'Installing Intellij artifacts to Maven local repository'
 echo "Intellij home: $INTELLIJ_HOME"
 
-mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/openapi.jar -DgroupId=com.intellij -DartifactId=openapi -Dversion=12.1.4 -Dpackaging=jar
-mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/util.jar -DgroupId=com.intellij -DartifactId=util -Dversion=12.1.4 -Dpackaging=jar
-mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/extensions.jar -DgroupId=com.intellij -DartifactId=extensions -Dversion=12.1.4 -Dpackaging=jar
-mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/annotations.jar -DgroupId=com.intellij -DartifactId=annotations -Dversion=12.1.4 -Dpackaging=jar
-mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/idea.jar -DgroupId=com.intellij -DartifactId=idea -Dversion=12.1.4 -Dpackaging=jar
-mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/trove4j.jar -DgroupId=net.sf.trove4j -DartifactId=trove4j -Dversion=12.1.4-idea -Dpackaging=jar
+mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/openapi.jar -DgroupId=com.intellij -DartifactId=openapi -Dversion=$INTELLIJ_VERSION -Dpackaging=jar
+mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/util.jar -DgroupId=com.intellij -DartifactId=util -Dversion=$INTELLIJ_VERSION -Dpackaging=jar
+mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/extensions.jar -DgroupId=com.intellij -DartifactId=extensions -Dversion=$INTELLIJ_VERSION -Dpackaging=jar
+mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/annotations.jar -DgroupId=com.intellij -DartifactId=annotations -Dversion=$INTELLIJ_VERSION -Dpackaging=jar
+mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/idea.jar -DgroupId=com.intellij -DartifactId=idea -Dversion=$INTELLIJ_VERSION -Dpackaging=jar
+mvn install:install-file -Dfile="$INTELLIJ_HOME"/lib/trove4j.jar -DgroupId=net.sf.trove4j -DartifactId=trove4j -Dversion=$INTELLIJ_VERSION-idea -Dpackaging=jar


### PR DESCRIPTION
In my yesterday pull request I accidentally pushed a script with version 12.1.4 of intellij. Here is a fix.
I introduced the INTELLIJ_VERSION variable to try to reduce the risk in the future.
