### PR TITLE
Support storyboard and table template

### DIFF
--- a/src/main/scala/fitnesse/idea/parser/FitnesseParser.scala
+++ b/src/main/scala/fitnesse/idea/parser/FitnesseParser.scala
@@ -147,6 +147,7 @@ class FitnesseParser extends PsiParser {
     case "table" => TableElementType.TABLE_TABLE
     case "comment" => TableElementType.COMMENT_TABLE
     case "scenario" => TableElementType.SCENARIO_TABLE
+    case "table template" => TableElementType.SCENARIO_TABLE
     case "define table type" => TableElementType.DEFINE_TABLE_TYPE_TABLE
     case "define alias" => TableElementType.DEFINE_ALIAS_TABLE
     case _ => TableElementType.UNKNOWN_TABLE

--- a/src/main/scala/fitnesse/idea/parser/FitnesseParser.scala
+++ b/src/main/scala/fitnesse/idea/parser/FitnesseParser.scala
@@ -141,6 +141,7 @@ class FitnesseParser extends PsiParser {
     case "subset query" => TableElementType.QUERY_TABLE
     case "ordered query" => TableElementType.QUERY_TABLE
     case "script" => TableElementType.SCRIPT_TABLE
+    case "storyboard" => TableElementType.SCRIPT_TABLE
     case "import" => TableElementType.IMPORT_TABLE
     case "library" => TableElementType.LIBRARY_TABLE
     case "table" => TableElementType.TABLE_TABLE

--- a/src/test/scala/fitnesse/idea/parser/TableParserSuite.scala
+++ b/src/test/scala/fitnesse/idea/parser/TableParserSuite.scala
@@ -671,6 +671,90 @@ class TableParserSuite extends ParserSuite {
     }
   }
 
+  test("Storyboard table with cell separator") {
+    assertResult(
+      Node(FitnesseElementType.FILE, List(
+        Node(TableElementType.SCRIPT_TABLE, List(
+          Leaf(FitnesseTokenType.TABLE_START, "|"),
+          Node(FitnesseElementType.ROW, List(
+            Node(FitnesseElementType.TABLE_TYPE, List(
+              Leaf(FitnesseTokenType.WORD, "storyboard")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Node(FitnesseElementType.FIXTURE_CLASS, List(
+              Leaf(FitnesseTokenType.WORD, "stuff")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "param1")
+            ))
+          )),
+          Leaf(FitnesseTokenType.ROW_END, "|\n|"),
+          Node(FitnesseElementType.SCRIPT_ROW, List(
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "foo"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "bar"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            ))
+          )),
+          Leaf(FitnesseTokenType.TABLE_END, "|")
+        ))
+      ))
+    ) {
+      parse("|storyboard|stuff|param1|\n|foo field|bar field|")
+    }
+  }
+
+  test("Storyboard table with extra white space") {
+    assertResult(
+      Node(FitnesseElementType.FILE, List(
+        Node(TableElementType.SCRIPT_TABLE, List(
+          Leaf(FitnesseTokenType.TABLE_START, "|"),
+          Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+          Node(FitnesseElementType.ROW, List(
+            Node(FitnesseElementType.TABLE_TYPE, List(
+              Leaf(FitnesseTokenType.WORD, "storyboard")
+            )),
+            Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+            Node(FitnesseElementType.FIXTURE_CLASS, List(
+              Leaf(FitnesseTokenType.WORD, "stuff")
+            ))
+          )),
+          Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+          Leaf(FitnesseTokenType.ROW_END, "|\n|"),
+          Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+          Node(FitnesseElementType.SCRIPT_ROW, List(
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "foo"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            )),
+            Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "bar"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            ))
+          )),
+          Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+          Leaf(FitnesseTokenType.TABLE_END, "|")
+        ))
+      ))
+    ) {
+      parse("|  storyboard  |  stuff  |\n|  foo field  |  bar field  |")
+    }
+  }
+
   test("Scenario table with colon separator") {
     assertResult(
       Node(FitnesseElementType.FILE, List(

--- a/src/test/scala/fitnesse/idea/parser/TableParserSuite.scala
+++ b/src/test/scala/fitnesse/idea/parser/TableParserSuite.scala
@@ -917,6 +917,89 @@ class TableParserSuite extends ParserSuite {
     }
   }
 
+
+  test("Table template table with cell separator") {
+    assertResult(
+      Node(FitnesseElementType.FILE, List(
+        Node(TableElementType.SCENARIO_TABLE, List(
+          Leaf(FitnesseTokenType.TABLE_START, "|"),
+          Node(FitnesseElementType.ROW, List(
+            Node(FitnesseElementType.TABLE_TYPE, List(
+              Leaf(FitnesseTokenType.WORD, "table"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "template")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Node(FitnesseElementType.SCENARIO_NAME, List(
+              Node(FitnesseElementType.CELL, List(
+                Leaf(FitnesseTokenType.WORD, "stuff")
+              ))
+            ))
+          )),
+          Leaf(FitnesseTokenType.ROW_END, "|\n|"),
+          Node(FitnesseElementType.SCRIPT_ROW, List(
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "foo"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "bar"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            ))
+          )),
+          Leaf(FitnesseTokenType.TABLE_END, "|")
+        ))
+      ))
+    ) {
+      parse("|table template|stuff|\n|foo field|bar field|")
+    }
+  }
+
+  test("Table template table with cell separator and extra spaces") {
+    assertResult(
+      Node(FitnesseElementType.FILE, List(
+        Node(TableElementType.SCENARIO_TABLE, List(
+          Leaf(FitnesseTokenType.TABLE_START, "|"),
+          Node(FitnesseElementType.ROW, List(
+            Node(FitnesseElementType.TABLE_TYPE, List(
+              Leaf(FitnesseTokenType.WORD, "table"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "template")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+            Node(FitnesseElementType.SCENARIO_NAME, List(
+              Node(FitnesseElementType.CELL, List(
+                Leaf(FitnesseTokenType.WORD, "stuff")
+              ))
+            ))
+          )),
+          Leaf(FitnesseTokenType.WHITE_SPACE, "  "),
+          Leaf(FitnesseTokenType.ROW_END, "|\n|"),
+          Node(FitnesseElementType.SCRIPT_ROW, List(
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "foo"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            )),
+            Leaf(FitnesseTokenType.CELL_END, "|"),
+            Node(FitnesseElementType.CELL, List(
+              Leaf(FitnesseTokenType.WORD, "bar"),
+              Leaf(FitnesseTokenType.WHITE_SPACE, " "),
+              Leaf(FitnesseTokenType.WORD, "field")
+            ))
+          )),
+          Leaf(FitnesseTokenType.TABLE_END, "|")
+        ))
+      ))
+    ) {
+      parse("|table template|  stuff  |\n|foo field|bar field|")
+    }
+  }
+
   test("import table") {
     assertResult(
       Node(FitnesseElementType.FILE, List(

--- a/src/test/scala/fitnesse/idea/scenariotable/ScenarioTableSuite.scala
+++ b/src/test/scala/fitnesse/idea/scenariotable/ScenarioTableSuite.scala
@@ -22,6 +22,18 @@ class ScenarioTableSuite extends PsiSuite {
     }
   }
 
+  test("find table name for table template") {
+    val table = createTable("| table template | my scenario table |")
+
+    assertResult("my scenario table") {
+      scenarioName(table).name
+    }
+
+    assertResult("MyScenarioTable") {
+      scenarioName(table).scenarioName
+    }
+  }
+
   test("find interposed table name") {
     val table = createTable("| scenario | my | val1 |scenario | val2 | table |")
 


### PR DESCRIPTION
Add support for Slim tables from https://github.com/fhoeben/hsac-fitnesse-plugin:
* 'storyboard': a script table subclass which adds a screenshot to each row
* 'table template': a scenario table subclass which finds its parameters by scanning its rows (instead of having formal parameters defined in its first row)